### PR TITLE
fix: child 폴더 버튼 사이즈 변경

### DIFF
--- a/src/domains/dotori-folder/components/ChildFolderListItem.tsx
+++ b/src/domains/dotori-folder/components/ChildFolderListItem.tsx
@@ -62,8 +62,8 @@ const ChildFolderItemBlock = styled.div<{ isChecked: boolean }>`
 const SelectButton = styled(CheckBox)<{ active: boolean }>`
   ${({ active }) => !active && `display:none;`}
   position: absolute;
-  top: 5px;
-  left: 4px;
+  top: 8px;
+  left: 8px;
   z-index: 50;
 `;
 

--- a/src/domains/dotori-folder/components/ChildFolderListItem.tsx
+++ b/src/domains/dotori-folder/components/ChildFolderListItem.tsx
@@ -41,8 +41,8 @@ function ChildFolderListItem({
 }
 
 const ChildFolderItemBlock = styled.div<{ isChecked: boolean }>`
-  width: 174px;
-  height: 36px;
+  width: 201px;
+  height: 40px;
   position: relative;
   ${({ isChecked }) => !isChecked && ` border: 1px solid ${palette.grayLight};`}
   border-radius: 6px;
@@ -51,7 +51,7 @@ const ChildFolderItemBlock = styled.div<{ isChecked: boolean }>`
   justify-content: center;
   font-size: 12px;
   color: ${palette.grayDarker};
-  margin-right: 24px;
+  margin-right: 20px;
   margin-bottom: 12px;
   padding-right: 8px;
   &:nth-child(4n) {


### PR DESCRIPTION
## 📑 작업리스트

- ChildFolderListItem (폴더 내부 하위 폴더 버튼) 사이즈 디자인 변경